### PR TITLE
Add Cas Authentication

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -26,7 +26,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $routeMiddleware = [
-        'auth' => \App\Http\Middleware\Authenticate::class,
+        'casauth' => \App\Http\Middleware\CasAuthenticate::class,
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
     ];

--- a/app/Http/Middleware/CasAuthenticate.php
+++ b/app/Http/Middleware/CasAuthenticate.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Contracts\Auth\Guard;
+use Xavrsl\Cas\Facades\Cas;
+
+class CASAuthenticate
+{
+    /**
+     * The Guard implementation.
+     *
+     * @var Guard
+     */
+    protected $casauth;
+
+    /**
+     * Create a new filter instance.
+     *
+     * @param  Guard  $casauth
+     */
+    public function __construct(Guard $casauth)
+    {
+        $this->casauth = $casauth;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        Cas::authenticate();
+
+        return $next($request);
+    }
+}

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -7,18 +7,17 @@ get('/', function () {
 get('grants', 'GrantController@index');
 get('grants/{slug}', 'GrantController@showGrant');
 
-// Admin area
-get('admin', function () {
-    return redirect('/admin/grant');
-});
-
 $router->group([
     'namespace' => 'Admin',
-    'middleware' => 'auth',
+    'middleware' => 'casauth',
+    'prefix' => 'admin'
 ], function () {
-    resource('admin/grant', 'GrantController', ['except' => 'show']);
-    resource('admin/tag', 'TagController');
-    get('admin/upload', 'UploadController@index');
+    get('/', function () {
+        return redirect('/admin/grant');
+    });
+    resource('grant', 'GrantController', ['except' => 'show']);
+    resource('tag', 'TagController');
+    get('upload', 'UploadController@index');
 });
 
 // Logging in and out

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
         "michelf/php-smartypants": "1.6.0-beta1",
         "laravel/homestead": "~2.1",
         "doctrine/dbal": "~2.5",
-        "laravelcollective/html": "5.1.*"
+        "laravelcollective/html": "5.1.*",
+        "xavrsl/cas": "1.2.*"
     },
     "require-dev": {
         "fzaninotto/faker": "~1.4",

--- a/config/app.php
+++ b/config/app.php
@@ -145,6 +145,7 @@ return [
         App\Providers\EventServiceProvider::class,
         App\Providers\RouteServiceProvider::class,
 
+        Xavrsl\Cas\CasServiceProvider::class,
     ],
 
     /*
@@ -194,6 +195,7 @@ return [
         'View'      => Illuminate\Support\Facades\View::class,
         'Html'      => Illuminate\Html\HtmlFacade::class,
         'Form'      => Illuminate\Html\FormFacade::class,
+        'Cas'       => Xavrsl\Cas\Facades\Cas::class
     ],
 
 ];

--- a/config/cas.php
+++ b/config/cas.php
@@ -1,0 +1,128 @@
+<?php
+
+return [
+        /*
+        |--------------------------------------------------------------------------
+        | PHPCas Debug
+        |--------------------------------------------------------------------------
+        |
+        | Example : '/var/log/phpCas.log'
+        | or true for default location (/tmp/phpCAS.log)
+        |
+        */
+
+        'cas_debug' => env('CAS_DEBUG', false),
+
+
+        /*
+        |--------------------------------------------------------------------------
+        | PHPCas Hostname
+        |--------------------------------------------------------------------------
+        |
+        | Exemple: 'cas.myuniv.edu'.
+        |
+        */
+
+        'cas_hostname' => env('CAS_HOSTNAME'),
+
+
+        /*
+        |--------------------------------------------------------------------------
+        | Cas Port
+        |--------------------------------------------------------------------------
+        |
+        | Usually 443 is default
+        |
+        */
+
+        'cas_port' => env('CAS_PORT', 443),
+
+
+        /*
+        |--------------------------------------------------------------------------
+        | CAS URI
+        |--------------------------------------------------------------------------
+        |
+        | Sometimes is /cas
+        |
+        */
+
+        'cas_uri' => env('CAS_URI', ''),
+
+
+        /*
+        |--------------------------------------------------------------------------
+        | CAS Validation
+        |--------------------------------------------------------------------------
+        |
+        | CAS server SSL validation: 'self' for self-signed certificate, 'ca' for
+        | certificate from a CA, empty for no SSL validation.
+        |
+        */
+
+        'cas_validation' => env('CAS_VALIDATION', ''),
+
+
+        /*
+        |--------------------------------------------------------------------------
+        | CAS Certificate
+        |--------------------------------------------------------------------------
+        |
+        | Path to the CAS certificate file
+        |
+        */
+
+        'cas_cert' => env('CAS_CERT', ''),
+
+
+        /*
+        |--------------------------------------------------------------------------
+        | Pretend to be a CAS user
+        |--------------------------------------------------------------------------
+        |
+        | This is useful in development mode. CAS is not called at all, only user
+        | is set.
+        |
+        */
+
+        'cas_pretend_user' => env('CAS_PRETEND_USER', ''),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Use as Cas proxy ?
+        |--------------------------------------------------------------------------
+        */
+
+         'cas_proxy' => env('CAS_PROXY', false),
+
+
+        /*
+        |--------------------------------------------------------------------------
+        | Enable service to be proxied
+        |--------------------------------------------------------------------------
+        |
+        | Example:
+        | phpCAS::allowProxyChain(new CAS_ProxyChain(array(
+        |                                 '/^https:\/\/app[0-9]\.example\.com\/rest\//',
+        |                                 'http://client.example.com/'
+        |                         )));
+        | For the exemple above:
+        |   'cas_proxied_services' => array('/^https:\/\/app[0-9]\.example\.com\/rest\//','http://client.example.com/'),
+        */
+
+         'cas_proxied_services' => array(),
+
+        /*
+        |--------------------------------------------------------------------------
+        | Use SAML to retrieve user attributes
+        |--------------------------------------------------------------------------
+        |
+        | Cas can be configured to return more than just the username to a given
+        | service. It could for example use an LDAP backend to return the first name,
+        | last name, and email of the user. This can be activated on the client side
+        | by setting 'cas_saml' to true.
+        |
+        */
+
+        'cas_saml' => env('CAS_SAML', false)
+];


### PR DESCRIPTION
This adds cas authentication using [XavRsl/Cas](https://github.com/XavRsl/Cas), a phpCas package for Laravel

cas configuration should be added to .env (see [config/cas.php](https://github.com/gpspake/grants/blob/cas/config/cas.php))

The cas certificate `cacerts_auth.pem` must be added to the project and the ca_cert path should be defined in .env
